### PR TITLE
[WEB-12] Token transfer failure is not properly handled

### DIFF
--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -1,0 +1,24 @@
+use near_contract_standards::non_fungible_token::TokenId;
+use near_sdk::{ext_contract, AccountId, Gas};
+
+pub const TGAS: u64 = 1_000_000_000_000;
+pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
+
+// Interface of this contract, for call backs
+#[ext_contract(this_contract)]
+trait Callbacks {
+    fn lending_accept_callback(&mut self) -> bool;
+}
+
+// NFT interface, for cross-contract calls
+#[ext_contract(nft)]
+trait Nft {
+    // cross-contract call
+    fn nft_transfer(
+        &mut self,
+        receiver_id: AccountId,
+        token_id: TokenId,
+        approval_id: Option<u64>,
+        memo: Option<String>,
+    );
+}

--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -7,6 +7,7 @@ use near_sdk::{ext_contract, AccountId};
 // }
 
 // NFT interface, for cross-contract calls
+// For details, refer to NEP-171
 #[ext_contract(ext_nft)]
 pub trait Nft {
     // cross-contract call
@@ -20,9 +21,10 @@ pub trait Nft {
 
     fn nft_transfer_call(
         &mut self,
-        receiver_id: AccountId,
-        token_id: TokenId,
-        memo: Option<String>,
-        msg: String,
+        receiver_id: AccountId,   // account to receive the token
+        token_id: TokenId,        // nft token to be sent
+        approval_id: Option<u64>, // approval ID, in case transfer is sent from ppl with valid approval
+        memo: Option<String>,     
+        msg: String,              // info needed by the receiving contract to handl the transfer.
     );
 }

--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -5,14 +5,14 @@ pub const TGAS: u64 = 1_000_000_000_000;
 pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
 
 // Interface of this contract, for call backs
-#[ext_contract(this_contract)]
-trait Callbacks {
+#[ext_contract(ext_self)]
+pub trait Callbacks {
     fn lending_accept_callback(&mut self) -> bool;
 }
 
 // NFT interface, for cross-contract calls
-#[ext_contract(nft)]
-trait Nft {
+#[ext_contract(ext_nft)]
+pub trait Nft {
     // cross-contract call
     fn nft_transfer(
         &mut self,
@@ -20,5 +20,13 @@ trait Nft {
         token_id: TokenId,
         approval_id: Option<u64>,
         memo: Option<String>,
+    );
+
+    fn nft_transfer_call(
+        &mut self,
+        receiver_id: AccountId,
+        token_id: TokenId,
+        memo: Option<String>,
+        msg: String,
     );
 }

--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -1,8 +1,5 @@
 use near_contract_standards::non_fungible_token::TokenId;
-use near_sdk::{ext_contract, AccountId, Gas};
-
-pub const TGAS: u64 = 1_000_000_000_000;
-pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
+use near_sdk::{ext_contract, AccountId};
 
 // // Interface of this contract, for call backs - place holder
 // #[ext_contract(ext_self)]

--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -4,11 +4,10 @@ use near_sdk::{ext_contract, AccountId, Gas};
 pub const TGAS: u64 = 1_000_000_000_000;
 pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
 
-// Interface of this contract, for call backs
-#[ext_contract(ext_self)]
-pub trait Callbacks {
-    fn lending_accept_callback(&mut self) -> bool;
-}
+// // Interface of this contract, for call backs - place holder
+// #[ext_contract(ext_self)]
+// pub trait Callbacks {
+// }
 
 // NFT interface, for cross-contract calls
 #[ext_contract(ext_nft)]

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,4 +1,3 @@
-use near_contract_standards::non_fungible_token::core::NonFungibleTokenReceiver;
 use near_contract_standards::non_fungible_token::TokenId;
 
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
@@ -91,7 +90,7 @@ impl Contract {
             "Deposit is less than the agreed rent!"
         );
 
-        // TODO: Handle the promise - Update the lease condition only when transfer succeeds
+        // Handle the promise - Update the lease condition only when transfer succeeds
         let promise = nft::ext(lease_condition.contract_addr.clone())
             .with_static_gas(Gas(5 * TGAS))
             .with_attached_deposit(1)
@@ -176,7 +175,7 @@ impl Contract {
         );
 
         // 4. transfer nft to owner
-        let promise = nft::ext(lease_condition.contract_addr.clone())
+        nft::ext(lease_condition.contract_addr.clone())
             .with_static_gas(Gas(5 * TGAS))
             .with_attached_deposit(1)
             .nft_transfer(
@@ -208,7 +207,7 @@ impl Contract {
 
     pub fn proxy_func_calls(&self, contract_id: AccountId, method_name: String, args: String) {
         // proxy function to open accessible functions calls in a NFT contract during lease
-        let mut promise = Promise::new(contract_id.clone());
+        let promise = Promise::new(contract_id.clone());
 
         // TODO: allow the lend to define white list of method names.
         // unreachable methods in leased NFT contract

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -8,6 +8,9 @@ use near_sdk::{
     env, log, near_bindgen, AccountId, Balance, BorshStorageKey, Gas, PanicOnDefault, Promise,
 };
 
+pub const TGAS: u64 = 1_000_000_000_000;
+pub const XCC_GAS: Gas = Gas(5 * TGAS); // cross contract gas
+
 pub mod externals;
 pub use crate::externals::*;
 
@@ -104,7 +107,6 @@ impl Contract {
                 None,
                 format!(r#"{{"lease_id":"{}"}}"#, &lease_id), // message should include the leaseID
             );
-    
     }
 
     pub fn leases_by_owner(&self, account_id: AccountId) -> Vec<(String, LeaseCondition)> {

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -57,7 +57,7 @@ pub struct LeaseCondition {
 #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
 pub struct Contract {
     owner: AccountId,
-    lease_map: UnorderedMap<LeaseId, LeaseCondition>, // <lending_id, lending>, storing all Lease records
+    lease_map: UnorderedMap<LeaseId, LeaseCondition>,
 }
 
 #[derive(BorshStorageKey, BorshSerialize)]
@@ -104,6 +104,7 @@ impl Contract {
                 None,
                 format!(r#"{{"lease_id":"{}"}}"#, &lease_id), // message should include the leaseID
             );
+    
     }
 
     pub fn leases_by_owner(&self, account_id: AccountId) -> Vec<(String, LeaseCondition)> {
@@ -230,7 +231,7 @@ impl NonFungibleTokenTransferReceiver for Contract {
             near_sdk::serde_json::from_str(&msg).expect("Not valid msg for nft_on_transfer");
 
         log!(
-            " Updating lease condition for lease_id: {}",
+            "Updating lease condition for lease_id: {}",
             &nft_on_transfer_json.lease_id
         );
 
@@ -243,12 +244,12 @@ impl NonFungibleTokenTransferReceiver for Contract {
         self.lease_map
             .insert(&nft_on_transfer_json.lease_id, &new_lease_condition);
 
-        // all updates are competed. Return false, so that nft_resolve_transfer() from nft contract will pick up
+        // all updates are completed. Return false, so that nft_resolve_transfer() from nft contract will not revert this transfer
         return false;
     }
 }
 
-//TODO: move nft callback function to separate file e.g. nft_callbacks.rs
+// TODO: move nft callback function to separate file e.g. nft_callbacks.rs
 /**
     trait that will be used as the callback from the NFT contract. When nft_approve is
     called, it will fire a cross contract call to this marketplace and this is the function

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,12 +1,11 @@
 use near_contract_standards::non_fungible_token::TokenId;
 
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::bs58;
 use near_sdk::collections::UnorderedMap;
 use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::{bs58, PromiseOrValue};
 use near_sdk::{
     env, log, near_bindgen, AccountId, Balance, BorshStorageKey, Gas, PanicOnDefault, Promise,
-    PromiseError, PromiseResult,
 };
 
 pub mod externals;
@@ -96,7 +95,7 @@ impl Contract {
             "Deposit is less than the agreed rent!"
         );
 
-        let promise = ext_nft::ext(lease_condition.contract_addr.clone())
+        ext_nft::ext(lease_condition.contract_addr.clone())
             .with_static_gas(Gas(10 * TGAS))
             .with_attached_deposit(1)
             .nft_transfer_call(
@@ -244,7 +243,7 @@ impl NonFungibleTokenTransferReceiver for Contract {
         self.lease_map
             .insert(&nft_on_transfer_json.lease_id, &new_lease_condition);
 
-        // all updates are competed. Send false, so that nft_resolve_transfer() from nft contract will pick up
+        // all updates are competed. Return false, so that nft_resolve_transfer() from nft contract will pick up
         return false;
     }
 }


### PR DESCRIPTION
[WEB-21](https://linear.app/web3cows/issue/WEB-21/token-transfer-failure-is-not-properly-handled)
Added promise handle for leanding_accept. Lease records table in the contract will only be updated if NFT has been successfully transferred from owner to  lease contract; If any error occured during handling, the NFT transfer will be revert. 

Updates:
- use nft_transfer_call method defined in [NEP171](https://nomicon.io/Standards/Tokens/NonFungibleToken/Core)
- implemented nft_on_approve and return a bool accordingly. Return of this method will be picked up by nft_resolve_transfer in NFT contract.
- created externals.rs file to keep cross contract call related features
- minor format / comment adjustment
