### PR TITLE
Fix the error when create lease on Mintbase NFTs.

### DIFF
--- a/frontend/src/NftContract.js
+++ b/frontend/src/NftContract.js
@@ -48,7 +48,8 @@ export async function newLease(
       account_id: nearConfig.contractName,
       msg: message,
     },
-    amount: "500000000000000000000",
+    gas: "300000000000000",
+    amount: "1000000000000000000000",
   });
   return tokens;
 }


### PR DESCRIPTION
Increase the deposit amount and gas.

Fix the error when create lease on Mintbase NFTs.

```
{"index":0,"kind":{"ExecutionError":"Smart contract panicked: Requires storage deposit of at least 800000000000000000000 yoctoNEAR (store/src/approvals.rs, 40:9)"}}
```