### PR TITLE
Setup up rust linter

### DIFF
--- a/contract/src/externals.rs
+++ b/contract/src/externals.rs
@@ -24,7 +24,7 @@ pub trait Nft {
         receiver_id: AccountId,   // account to receive the token
         token_id: TokenId,        // nft token to be sent
         approval_id: Option<u64>, // approval ID, in case transfer is sent from ppl with valid approval
-        memo: Option<String>,     
-        msg: String,              // info needed by the receiving contract to handl the transfer.
+        memo: Option<String>,
+        msg: String, // info needed by the receiving contract to handl the transfer.
     );
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -40,7 +40,7 @@ pub struct NftOnTransferJson {
     lease_id: String,
 }
 
-//struct for keeping track of the lease conditions
+// struct for keeping track of the lease conditions
 #[derive(BorshDeserialize, BorshSerialize, Serialize)]
 #[serde(crate = "near_sdk::serde")]
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "license": "(MIT AND Apache-2.0)",
   "scripts": {
+    "lint": "cd contract && cargo fmt && cargo clippy",
     "start": "cd frontend && yarn start",
     "deploy": "yarn build:contract && cd contract && near dev-deploy --wasmFile ./target/wasm32-unknown-unknown/release/nft_rental.wasm",
     "deploy_testnet": "yarn build:contract && cd contract && near deploy --wasmFile ./target/wasm32-unknown-unknown/release/nft_rental.wasm --accountId nft-rental.testnet",


### PR DESCRIPTION
Run `yarn lint` at the root directory of the code repo to do the formating and code linting.

The lint warnings will be cleaned in the following PR.

See more: https://github.com/rust-lang/rust-clippy